### PR TITLE
Fix multilingual strings displayed in frontend hooks

### DIFF
--- a/ps_legalcompliance.php
+++ b/ps_legalcompliance.php
@@ -1024,7 +1024,7 @@ class Ps_LegalCompliance extends Module
 
     private function dumpHookDisplayProductPriceBlock(array $smartyVars, $hook_type, $additional_cache_param = false)
     {
-        $cache_id = sha1($hook_type.$additional_cache_param);
+        $cache_id = sha1($hook_type.$additional_cache_param.$this->context->language->id);
         $this->context->smarty->assign(array('smartyVars' => $smartyVars));
         $this->context->controller->addJS($this->_path.'views/js/fo_aeuc_tnc.js', true);
         $template = 'hookDisplayProductPriceBlock_'.$hook_type.'.tpl';


### PR DESCRIPTION
Without this fix the caching system only caches a single language version of any frontend block, which renders multilanguage shops impossible, as the same language version of the templates is displayed for every shop language.

Before the patch hookDisplayProductPriceBlock_price.tpl renders this following text:
In the english shop `Shipping excluded` 
and this text in e.g. the german shop `Shipping excluded`

After the patch hookDisplayProductPriceBlock_price.tpl renders this following (correct) text:
In the english shop `Shipping excluded` 
and this text in e.g. the german shop `Zzgl. Versandkosten`